### PR TITLE
Removes unneeded security context from K8S sample

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -71,10 +71,6 @@ spec:
           mountPath: /userapp
         - name: trader-volume
           mountPath: /trader
-      securityContext:
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
       volumes:
         - name: trader-volume
           configMap:

--- a/kubernetes/spiceai-deployment.yaml
+++ b/kubernetes/spiceai-deployment.yaml
@@ -31,10 +31,6 @@ spec:
           mountPath: /userapp
         - name: trader-volume
           mountPath: /trader
-      securityContext:
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
       volumes:
         - name: trader-volume
           configMap:


### PR DESCRIPTION
After removing the 1000 user in our Dockerfile, the K8S sample was throwing permissions errors trying to create a log file.  This change fixes that.  Closes #29 