### PR TITLE
Use spice run instead of service container

### DIFF
--- a/.github/workflows/gardener.yml
+++ b/.github/workflows/gardener.yml
@@ -20,22 +20,9 @@ jobs:
   test:
     name: test gardener
     runs-on: ubuntu-latest
-    env:
-      GOVER: 1.17
-    services:
-      spiceai:
-        # Use latest released version to ensure incoming sample changes do not break it 
-        image: ghcr.io/spiceai/spiceai:0.2-alpha-linux-amd64
-        ports:
-          - 8000:8000
-        options: -v ${{ github.workspace }}/gardener:/userapp --name spicert
+    
     steps:
       - uses: actions/checkout@v2
-
-      - name: Restart spicert
-        uses: docker://docker
-        with:
-          args: docker restart spicert
 
       - name: update PATH
         run: |
@@ -45,9 +32,13 @@ jobs:
         run: |
           curl https://install.spiceai.org | /bin/bash
 
+      - name: start Spice.ai runtime
+        run: |
+          spice run &
+
       - name: wait for Spice.ai runtime healthy
         run: |
-          timeout 30 bash -c 'while [[ "$(curl -s -w 200 http://localhost:8000/health)" != "ok200" ]]; do sleep 1; done' || false
+          timeout 120 bash -c 'while [[ "$(curl -s -w 200 http://localhost:8000/health)" != "ok200" ]]; do sleep 1; done' || false
 
       - name: fetch diagnostics
         run: |

--- a/.github/workflows/serverops.yml
+++ b/.github/workflows/serverops.yml
@@ -20,8 +20,6 @@ jobs:
   test:
     name: test serverops
     runs-on: ubuntu-latest
-    env:
-      GOVER: 1.17
     steps:
       - uses: actions/checkout@v2
 
@@ -76,4 +74,4 @@ jobs:
 
       - name: check output for success
         run: |
-          grep -E "now|performing" serverops.out && echo "Found successful action based on recommendation" || exit 1
+          grep -E "any|now" serverops.out && echo "Found successful action based on recommendation" || exit 1


### PR DESCRIPTION
Uses `spice run` instead of a service container in the gardener sample test to bring it more in line with what an actual user would do.

Removes unnecessary env vars.

Brings success criteria for serverops in line with what is in the quickstart.