### PR TITLE
Break the cache if there is a new commit to spiceai/spiceai

### DIFF
--- a/acceleration/Dockerfile.spiceai
+++ b/acceleration/Dockerfile.spiceai
@@ -2,6 +2,7 @@ FROM debian as build
 
 RUN apt-get update && apt-get install -yqq curl jq
 
+ADD "https://api.github.com/repos/spiceai/spiceai/commits?per_page=1" latest_commit
 RUN curl https://install.spiceai.org/install-spiced.sh | /bin/bash
 
 FROM debian

--- a/sales-bi/Dockerfile
+++ b/sales-bi/Dockerfile
@@ -2,6 +2,7 @@ FROM debian as build
 
 RUN apt-get update && apt-get install -yqq curl jq
 
+ADD "https://api.github.com/repos/spiceai/spiceai/commits?per_page=1" latest_commit
 RUN curl https://install.spiceai.org/install-spiced.sh | /bin/bash
 
 FROM debian


### PR DESCRIPTION
Invalides the Docker build cache by leveraging the `ADD` command in the Dockerfile.

`ADD "https://api.github.com/repos/spiceai/spiceai/commits?per_page=1" latest_commit`

This works because Docker will check the contents of the URL, and if it differs from the response it had when it previously built the Docker image, it will invalidate the cache and rebuild it.

From: https://docs.docker.com/reference/dockerfile/#add
<img width="808" alt="Screenshot 2024-04-02 at 1 18 12 PM" src="https://github.com/spiceai/samples/assets/879445/ca9bf3e4-26f1-4d88-90ec-5aa253dd18f5">
