### PR TITLE
Add `file_format` param where it is requred

### DIFF
--- a/client-sdk/gospice-sdk-sample/spicepod.yaml
+++ b/client-sdk/gospice-sdk-sample/spicepod.yaml
@@ -6,6 +6,8 @@ datasets:
 - from: s3://spiceai-demo-datasets/taxi_trips/2024/
   name: taxi_trips
   description: taxi trips in s3
+  params:
+    file_format: parquet
   acceleration:
     enabled: true
     refresh_check_interval: 10s

--- a/client-sdk/spice-rs-sdk-sample/spicepod.yaml
+++ b/client-sdk/spice-rs-sdk-sample/spicepod.yaml
@@ -6,6 +6,8 @@ datasets:
 - from: s3://spiceai-demo-datasets/taxi_trips/2024/
   name: taxi_trips
   description: taxi trips in s3
+  params:
+    file_format: parquet
   acceleration:
     enabled: true
     refresh_check_interval: 10s

--- a/client-sdk/spice.js-sdk-sample/spicepod.yaml
+++ b/client-sdk/spice.js-sdk-sample/spicepod.yaml
@@ -6,6 +6,8 @@ datasets:
 - from: s3://spiceai-demo-datasets/taxi_trips/2024/
   name: taxi_trips
   description: taxi trips in s3
+  params:
+    file_format: parquet
   acceleration:
     enabled: true
     refresh_check_interval: 10s

--- a/client-sdk/spicepy-sdk-sample/spicepod.yaml
+++ b/client-sdk/spicepy-sdk-sample/spicepod.yaml
@@ -6,6 +6,8 @@ datasets:
 - from: s3://spiceai-demo-datasets/taxi_trips/2024/
   name: taxi_trips
   description: taxi trips in s3
+  params:
+    file_format: parquet
   acceleration:
     enabled: true
     refresh_check_interval: 10s


### PR DESCRIPTION
`file_format` needs to be specified, when spice can't detect file extension