### PR TITLE
Add ODBC library to acceleration sample

### DIFF
--- a/acceleration/Dockerfile.spiceai
+++ b/acceleration/Dockerfile.spiceai
@@ -7,7 +7,7 @@ RUN curl https://install.spiceai.org/install-spiced.sh | /bin/bash
 
 FROM debian
 
-RUN apt-get update && apt-get install -yqq libssl-dev
+RUN apt-get update && apt-get install -yqq libssl-dev unixodbc-dev
 
 COPY --from=build /usr/local/bin/spiced /usr/local/bin
 


### PR DESCRIPTION
## 🗣 Description

Fixes the acceleration sample to work after v0.16 requires the ODBC driver to be installed.
