### PR TITLE
Update tls doc to contain --tls-enabled flag in spice run

### DIFF
--- a/tls/README.md
+++ b/tls/README.md
@@ -103,6 +103,16 @@ With the certificate and key generated, run the `spiced` service with TLS enable
 spice run -- --tls-enabled true --tls-certificate-file ./spiced.crt --tls-key-file ./spiced.key
 ```
 
+```bash
+2024-08-05T19:59:09.203647Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
+2024-08-05T19:59:09.203554Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
+2024-08-05T19:59:09.204194Z  INFO runtime: Initialized results cache; max size: 128.00 MiB, item ttl: 1s
+2024-08-05T19:59:09.205240Z  INFO runtime: Endpoints secured with TLS using certificate: CN=spiced.localhost, OU=IT, O=Widgets, Inc., L=Seattle, S=Washington, C=US
+2024-08-05T19:59:09.205622Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
+2024-08-05T19:59:09.211074Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
+2024-08-05T19:59:09.286775Z  INFO runtime: Dataset customer_addresses registered (postgres:customer_addresses), results cache enabled.
+```
+
 ## Verify the TLS connection
 
 In a separate terminal, verify the TLS connection using cURL.

--- a/tls/README.md
+++ b/tls/README.md
@@ -100,7 +100,7 @@ docker compose up -d
 With the certificate and key generated, run the `spiced` service with TLS enabled.
 
 ```bash
-spice run -- --tls-certificate-file ./spiced.crt --tls-key-file ./spiced.key
+spice run -- --tls-enabled true --tls-certificate-file ./spiced.crt --tls-key-file ./spiced.key
 ```
 
 ## Verify the TLS connection
@@ -121,7 +121,7 @@ go run main.go
 ```
 
 Output:
-  
+
 ```bash
 Successfully found Viv
 ```


### PR DESCRIPTION
## 🗣 Description

* Update tls doc to contain --tls-enabled flag in spice run
* Add terminal results in spice run with tls enabled

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
