### PR TITLE
Use ubuntu image for constaints sample due to segfault

### DIFF
--- a/constraints/Dockerfile.spiceai
+++ b/constraints/Dockerfile.spiceai
@@ -1,11 +1,11 @@
-FROM debian as build
+FROM ubuntu as build
 
 RUN apt-get update && apt-get install -yqq curl jq
 
 ADD "https://api.github.com/repos/spiceai/spiceai/commits?per_page=1" latest_commit
 RUN curl https://install.spiceai.org/install-spiced.sh | /bin/bash
 
-FROM debian
+FROM ubuntu
 
 RUN apt-get update && apt-get install -yqq libssl-dev
 


### PR DESCRIPTION
## 🗣 Description

When running with the Debian image, `spiced` was segfaulting at startup. With the `ubuntu` image, it runs fine.
