### PR TITLE
remove SQlite cache on `make clean`.

### DIFF
--- a/cdc-debezium/Makefile
+++ b/cdc-debezium/Makefile
@@ -7,6 +7,7 @@ clean:
 	@docker compose down
 	@docker volume prune -f
 	@docker image prune -f
+	rm -r .spice
 
 .PHONY: register-connector
 register-connector:


### PR DESCRIPTION
## 🗣 Description
 - For `cdc-debezium/`, we have sqlite acceleration cache in `cdc-debezium/.spice`
 - On `make clean`, we should remove the cache so when a user does the quickstart twice, they experience CDC updates correctly. 
