### PR TITLE
Update NodeJS SDK sample

### DIFF
--- a/client-sdk/spice.js-sdk-sample/README.md
+++ b/client-sdk/spice.js-sdk-sample/README.md
@@ -6,6 +6,13 @@
 spice run
 ```
 
+Ensure the dataset `taxi_trips` to be loaded
+```shell
+2024-09-23T21:54:09.980654Z  INFO runtime: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (arrow, 10s refresh), results cache enabled.
+2024-09-23T21:54:09.981827Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
+2024-09-23T21:55:10.491380Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (421.71 MiB) for dataset taxi_trips in 109ms.
+```
+
 ## Install dependencies
 
 ```shell


### PR DESCRIPTION
`npm start` will return a empty result if ran before `taxi_trips` is loaded.
