### PR TITLE
Update cdc-debezium sample

### DIFF
--- a/cdc-debezium/README.md
+++ b/cdc-debezium/README.md
@@ -139,6 +139,4 @@ If you don't have the `make` command available, you can run the following comman
 
 ```bash
 docker compose down
-docker volume prune -f
-docker image prune -f
 ```


### PR DESCRIPTION
Remove prune step as it will delete other images/volumes as well not just used in the sample.

```shell
docker volume prune -f
docker image prune -f
```

