### PR TITLE
Add `ca-certificates` to custom Docker images with spiced

### DIFF
--- a/acceleration/Dockerfile.spiceai
+++ b/acceleration/Dockerfile.spiceai
@@ -7,7 +7,7 @@ RUN curl https://install.spiceai.org/install-spiced.sh | /bin/bash
 
 FROM debian
 
-RUN apt-get update && apt-get install -yqq libssl-dev unixodbc-dev
+RUN apt-get update && apt-get install -yqq libssl-dev unixodbc-dev ca-certificates
 
 COPY --from=build /usr/local/bin/spiced /usr/local/bin
 

--- a/constraints/Dockerfile.spiceai
+++ b/constraints/Dockerfile.spiceai
@@ -7,7 +7,7 @@ RUN curl https://install.spiceai.org/install-spiced.sh | /bin/bash
 
 FROM ubuntu
 
-RUN apt-get update && apt-get install -yqq libssl-dev
+RUN apt-get update && apt-get install -yqq libssl-dev ca-certificates
 
 COPY --from=build /usr/local/bin/spiced /usr/local/bin
 


### PR DESCRIPTION
## 🗣 Description

Adds `ca-certificates` to allow spiced within the Docker images to be able to connect to the anonymous telemetry endpoint.

## 🔨 Related Issues

Part of https://github.com/spiceai/spiceai/issues/2994

